### PR TITLE
Webhooks use profile.identifier

### DIFF
--- a/javascript/src/handleDSRWebhook.js
+++ b/javascript/src/handleDSRWebhook.js
@@ -21,7 +21,7 @@ module.exports = asyncHandler(async function handleDSRWebhook(req, res) {
   console.info(`Received DSR webhook - https://app.transcend.io${req.body.extras.request.link}`);
 
   // Extract metadata from the webhook
-  const userIdentifier = req.body.profile.identifier; // req.body.profile.type will tell you if this is an email vs username, vs other identifier
+  const userIdentifier = req.body.extras.profile.identifier; // req.body.extras.profile.type will tell you if this is an email vs username, vs other identifier
   const webhookType = req.body.type; // ACCESS, ERASURE, etc: https://docs.transcend.io/docs/receiving-webhooks#events
   const nonce = req.headers['x-transcend-nonce'];
 

--- a/javascript/src/handleDSRWebhook.js
+++ b/javascript/src/handleDSRWebhook.js
@@ -21,7 +21,7 @@ module.exports = asyncHandler(async function handleDSRWebhook(req, res) {
   console.info(`Received DSR webhook - https://app.transcend.io${req.body.extras.request.link}`);
 
   // Extract metadata from the webhook
-  const userIdentifier = req.body.coreIdentifier.value;
+  const userIdentifier = req.body.profile.identifier; // req.body.profile.type will tell you if this is an email vs username, vs other identifier
   const webhookType = req.body.type; // ACCESS, ERASURE, etc: https://docs.transcend.io/docs/receiving-webhooks#events
   const nonce = req.headers['x-transcend-nonce'];
 

--- a/javascript/src/helpers/verifyAndExtractWebhook.js
+++ b/javascript/src/helpers/verifyAndExtractWebhook.js
@@ -13,7 +13,7 @@ let cachedPublicKey;
  *
  * Transcend developers: A design choice was made not to put webhook verification on an Express middleware. It's a nice refactor, but it can be esoteric to readers.
  *
- * @param {string} signedToken - the JSON Web Token asymetrically signed with ES384.
+ * @param {string} signedToken - the JSON Web Token asymmetrically signed with ES384.
  * @returns {Object} - the signed body
  */
 module.exports = async function verifyAndExtractWebhook(signedToken) {

--- a/python/main.py
+++ b/python/main.py
@@ -178,7 +178,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
         # Verify that the request came from Transcend
         verify_transcend_webhook(self.headers)
 
-        userIdentifier = body['profile']['identifier']
+        userIdentifier = body['extras']['profile']['identifier']
 
         # Determine whether the request should be blocked
         status = 'COMPILING'

--- a/ruby/server.rb
+++ b/ruby/server.rb
@@ -68,7 +68,7 @@ post '/' do
     begin
         validate_transcend_webhook token
         dsr_status = 'COMPILING'
-        user_identifier = payload['profile']['identifier']
+        user_identifier = payload['extras']['profile']['identifier']
 
 
         if $IS_A_FRAUD[user_identifier]


### PR DESCRIPTION
Noticed that the examples were all assuming that the servers were looking up by the core identifier. This changes updates the examples to allow for webhooks to respond to arbitrary identifier types.

Take the following workflow:

1. Data subject submits a DSR with a user
2. Enricher resolves email -> username
3. server silo takes in a username to perform an opt out.

In this case the profileId should be the username, not the core identifier/email.

[Updated Receiving DSR docs](https://docs.transcend.io/docs/receiving-webhooks#4-process-the-request)
[Updated Upload to our API docs](https://docs.transcend.io/docs/responding-to-dsrs#fulfill-an-erasure-request-dser-or-opt-out-request)