### PR TITLE
Adds header to get_transcend_public_key

### DIFF
--- a/python/main.py
+++ b/python/main.py
@@ -55,10 +55,9 @@ IS_A_FRAUD = {
 
 """
 Get the sombra public key, used to verify the request
-TODO: add authentication headers for multi-tenant Sombra in this example
 """
 def get_transcend_public_key():
-    res = requests.get(SOMBRA_URL + '/public-keys/sombra-general-signing-key', verify = not TRUST_SELF_SIGNED_CERT)
+    res = requests.get(SOMBRA_URL + '/public-keys/sombra-general-signing-key', verify = not TRUST_SELF_SIGNED_CERT, headers = { "authorization": "Bearer {}".format(TRANSCEND_API_KEY) })
     return res.content
 
 """


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- Closes https://transcend.height.app/T-10647

## Description

- adds Bearer token to get_transcend_public_key()
- not seeing where this is missing for the JS example?