### PR TITLE
Update javascript dotenv library, publish it on the ci and try to fix error when adding the package to the main project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build the typescript code
-        run: cd typescript && yarn build
+        run: cd typescript && yarn && yarn build
       - uses: actions/upload-artifact@main
         with:
           name: build artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,22 @@ jobs:
       - uses: pre-commit/action@v2.0.2
         with:
           extra_args: --source ${{ github.event.pull_request.base.sha || 'HEAD~1' }} --origin ${{ github.event.pull_request.head.sha || 'HEAD' }}
+
+  build-to-npm:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    needs:
+      - run-depcheck
+      - run-pre-commits
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+      - name: Configure NPM authentication
+        run: |
+          yarn config set npmAlwaysAuth true
+          yarn config set npmAuthToken ${{ secrets.NPM_TOKEN }}
+      - name: Publish to yarn/npm
+        run: cd typescript && yarn npm publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,24 @@ jobs:
           yarn config set npmAuthToken ${{ secrets.NPM_TOKEN }}
       - name: Publish to yarn/npm
         run: cd typescript && yarn npm publish
+
+  build-to-github-packages:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    needs:
+      - run-depcheck
+      - run-pre-commits
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+      - name: Configure Github Packages authentication
+        run: |
+          yarn config set npmAlwaysAuth true
+          yarn config set npmRegistryServer https://npm.pkg.github.com
+          yarn config set npmPublishRegistry https://npm.pkg.github.com
+          yarn config set npmAuthToken ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish to Github packages
+        run: cd typescript && yarn npm publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,23 @@ jobs:
         with:
           extra_args: --source ${{ github.event.pull_request.base.sha || 'HEAD~1' }} --origin ${{ github.event.pull_request.head.sha || 'HEAD' }}
 
+  build-and-upload-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build the typescript code
+        run: cd typescript && yarn build
+      - uses: actions/upload-artifact@main
+        with:
+          name: build artifacts
+          path: build/
+
   build-to-npm:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs:
       - run-depcheck
+      - build-and-upload-artifacts
       - run-pre-commits
     steps:
       - name: Checkout
@@ -53,6 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - run-depcheck
+      - build-and-upload-artifacts
       - run-pre-commits
     steps:
       - name: Checkout

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.19.0",
-    "dotenv": "^8.2.0",
+    "dotenv": "^8.6.0",
     "express": "^4.17.1",
     "express-async-handler": "^1.1.4",
     "got": "^11.6.2",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "prepublish": "yarn build",
-    "build": "tsc --build",
+    "build": "BUILD_PATH='./build' tsc --build",
     "clean": "tsc --build --clean",
     "start": "ts-node ./src/app.ts",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-webhook-example",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Example of a webhook that can be integrated with Transcend.",
   "main": "src/app.ts",
   "type": "module",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Example of a webhook that can be integrated with Transcend.",
   "main": "src/app.ts",
+  "type": "module",
   "files": [
     "src/**/*",
     "package.json"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "typescript-webhook-example",
+  "name": "@transcend-io/typescript-webhook-example",
   "version": "1.0.1",
   "description": "Example of a webhook that can be integrated with Transcend.",
   "main": "src/app.ts",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -2,13 +2,14 @@
   "name": "@transcend-io/typescript-webhook-example",
   "version": "1.0.1",
   "description": "Example of a webhook that can be integrated with Transcend.",
-  "main": "src/app.ts",
+  "main": "build/app.js",
   "type": "module",
   "files": [
-    "src/**/*",
+    "build/**/*",
     "package.json"
   ],
   "scripts": {
+    "prepublish": "yarn build",
     "build": "tsc --build",
     "clean": "tsc --build --clean",
     "start": "ts-node ./src/app.ts",

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -3,7 +3,7 @@
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "target": "esnext",
-    "outDir": "./out/" /* Redirect output structure to the directory. */,
+    "outDir": "./build/" /* Redirect output structure to the directory. */,
     "rootDir": "./src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
     "strict": true /* Enable all strict type-checking options. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -335,6 +335,26 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@transcend-io/typescript-webhook-example@workspace:typescript":
+  version: 0.0.0-use.local
+  resolution: "@transcend-io/typescript-webhook-example@workspace:typescript"
+  dependencies:
+    "@types/express": ^4.17.13
+    "@types/jsonwebtoken": ^8.5.8
+    "@types/morgan": ^1.9.3
+    "@types/node": ^17.0.29
+    dotenv: ^8.2.0
+    express: ^4.17.1
+    express-async-handler: ^1.1.4
+    got: ^11.6.2
+    jsonwebtoken: ^8.5.1
+    morgan: ^1.10.0
+    nodemon: ^2.0.4
+    ts-node: ^10.7.0
+    typescript: ^4.6.3
+  languageName: unknown
+  linkType: soft
+
 "@tsconfig/node10@npm:^1.0.7":
   version: 1.0.8
   resolution: "@tsconfig/node10@npm:1.0.8"
@@ -5261,26 +5281,6 @@ __metadata:
   checksum: 99c11aaa8f45189fcfba6b8a4825fd684a321caa9bd7a76a27cf0c7732c174d198b99f449c52c3818107430b5f41c0ccbbfb75cb2ee3ca4a9451710986d61a60
   languageName: node
   linkType: hard
-
-"typescript-webhook-example@workspace:typescript":
-  version: 0.0.0-use.local
-  resolution: "typescript-webhook-example@workspace:typescript"
-  dependencies:
-    "@types/express": ^4.17.13
-    "@types/jsonwebtoken": ^8.5.8
-    "@types/morgan": ^1.9.3
-    "@types/node": ^17.0.29
-    dotenv: ^8.2.0
-    express: ^4.17.1
-    express-async-handler: ^1.1.4
-    got: ^11.6.2
-    jsonwebtoken: ^8.5.1
-    morgan: ^1.10.0
-    nodemon: ^2.0.4
-    ts-node: ^10.7.0
-    typescript: ^4.6.3
-  languageName: unknown
-  linkType: soft
 
 "typescript@npm:^4.6.3":
   version: 4.6.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -1876,7 +1876,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^8.2.0":
+"dotenv@npm:^8.2.0, dotenv@npm:^8.6.0":
   version: 8.6.0
   resolution: "dotenv@npm:8.6.0"
   checksum: 38e902c80b0666ab59e9310a3d24ed237029a7ce34d976796349765ac96b8d769f6df19090f1f471b77a25ca391971efde8a1ea63bb83111bd8bec8e5cc9b2cd
@@ -2058,7 +2058,7 @@ __metadata:
   resolution: "eshopit@workspace:javascript"
   dependencies:
     body-parser: ^1.19.0
-    dotenv: ^8.2.0
+    dotenv: ^8.6.0
     express: ^4.17.1
     express-async-handler: ^1.1.4
     got: ^11.6.2


### PR DESCRIPTION
This PR adds a CI step to publish the typescript package when merged to master. It also changes the `type` on package.json to `module` to try to fix the problem of trying to run the server webhook on the main repo: https://github.com/transcend-io/main/pull/16205/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R92

Also this updates the dotenv library to try to get render to start the project so that we can deploy it to dev/staging/prod to test it out

![Screen Shot 2022-05-04 at 2 07 14 PM](https://user-images.githubusercontent.com/1494348/166827411-487042cb-39a2-420b-b665-e8e2e66ec6ea.png)

## Related Issues

- _[none]_

## Security Implications

_[none]_

## System Availability

_[none]_
