### PR TITLE
Fix render webhooks

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -16,7 +16,7 @@
     "dotenv": "^8.6.0",
     "express": "^4.18.1",
     "express-async-handler": "^1.2.0",
-    "got": "^11.8.3",
+    "got": "=11.8.3",
     "jsonwebtoken": "^8.5.1",
     "morgan": "^1.10.0"
   },

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -16,7 +16,7 @@
     "dotenv": "^8.6.0",
     "express": "^4.18.1",
     "express-async-handler": "^1.2.0",
-    "got": "^12.1.0",
+    "got": "^11.8.3",
     "jsonwebtoken": "^8.5.1",
     "morgan": "^1.10.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -332,7 +332,7 @@ __metadata:
     dotenv: ^8.6.0
     express: ^4.18.1
     express-async-handler: ^1.2.0
-    got: ^12.1.0
+    got: ^11.8.3
     jsonwebtoken: ^8.5.1
     morgan: ^1.10.0
     nodemon: ^2.0.4
@@ -2851,6 +2851,25 @@ __metadata:
     p-cancelable: ^2.0.0
     responselike: ^2.0.0
   checksum: 3b6db107d9765470b18e4cb22f7c7400381be7425b9be5823f0168d6c21b5d6b28b023c0b3ee208f73f6638c3ce251948ca9b54a1e8f936d3691139ac202d01b
+  languageName: node
+  linkType: hard
+
+"got@npm:^11.8.3":
+  version: 11.8.5
+  resolution: "got@npm:11.8.5"
+  dependencies:
+    "@sindresorhus/is": ^4.0.0
+    "@szmarczak/http-timer": ^4.0.5
+    "@types/cacheable-request": ^6.0.1
+    "@types/responselike": ^1.0.0
+    cacheable-lookup: ^5.0.3
+    cacheable-request: ^7.0.2
+    decompress-response: ^6.0.0
+    http2-wrapper: ^1.0.0-beta.5.2
+    lowercase-keys: ^2.0.0
+    p-cancelable: ^2.0.0
+    responselike: ^2.0.0
+  checksum: 2de8a1bbda4e9b6b2b72b2d2100bc055a59adc1740529e631f61feb44a8b9a1f9f8590941ed9da9df0090b6d6d0ed8ffee94cd9ac086ec3409b392b33440f7d2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -332,7 +332,7 @@ __metadata:
     dotenv: ^8.6.0
     express: ^4.18.1
     express-async-handler: ^1.2.0
-    got: ^11.8.3
+    got: =11.8.3
     jsonwebtoken: ^8.5.1
     morgan: ^1.10.0
     nodemon: ^2.0.4
@@ -2851,25 +2851,6 @@ __metadata:
     p-cancelable: ^2.0.0
     responselike: ^2.0.0
   checksum: 3b6db107d9765470b18e4cb22f7c7400381be7425b9be5823f0168d6c21b5d6b28b023c0b3ee208f73f6638c3ce251948ca9b54a1e8f936d3691139ac202d01b
-  languageName: node
-  linkType: hard
-
-"got@npm:^11.8.3":
-  version: 11.8.5
-  resolution: "got@npm:11.8.5"
-  dependencies:
-    "@sindresorhus/is": ^4.0.0
-    "@szmarczak/http-timer": ^4.0.5
-    "@types/cacheable-request": ^6.0.1
-    "@types/responselike": ^1.0.0
-    cacheable-lookup: ^5.0.3
-    cacheable-request: ^7.0.2
-    decompress-response: ^6.0.0
-    http2-wrapper: ^1.0.0-beta.5.2
-    lowercase-keys: ^2.0.0
-    p-cancelable: ^2.0.0
-    responselike: ^2.0.0
-  checksum: 2de8a1bbda4e9b6b2b72b2d2100bc055a59adc1740529e631f61feb44a8b9a1f9f8590941ed9da9df0090b6d6d0ed8ffee94cd9ac086ec3409b392b33440f7d2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
All deploys of the javascript webhook are failing. This fixes it by downgrading the got version: https://bobbyhadz.com/blog/javascript-got-error-err-require-esm-of-es-module

![Screen Shot 2022-06-28 at 1 59 48 PM](https://user-images.githubusercontent.com/1494348/176286865-00386927-2c75-43cb-a995-6c03552d61a3.png)

## Security Implications

_[none]_

## System Availability

_[none]_
