### PR TITLE
Fixed Sombra URL in README

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -50,7 +50,7 @@ Else you can use your certificate and private key, and set it on the code on mai
 
 If you want to verify the JWT token, you need to set the `AUDIENCE` environment variable.
 
-You can find the audience on your Organization URI at https://app.transcend.io/infrastructure/sombra.
+You can find the audience on your Organization URI at https://app.transcend.io/infrastructure/sombra/sombras.
 
 ### TRANSCEND_API_KEY
 


### PR DESCRIPTION
The URL (apparently) wasn't valid in the Transcend application, I think it should point to sombra/sombras

## Related Issues

- _[none]_

## Security Implications

_[none]_

## System Availability

_[none]_
